### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/liangzhu0810/52d4b51b-cd61-4aea-a7e1-fc96c7343a6a/91929124-4d93-4acd-b7fe-b012541b9c1c/_apis/work/boardbadge/43e96b35-de86-4a86-825f-70392c5f9703)](https://dev.azure.com/liangzhu0810/52d4b51b-cd61-4aea-a7e1-fc96c7343a6a/_boards/board/t/91929124-4d93-4acd-b7fe-b012541b9c1c/Microsoft.RequirementCategory)
 ## My Work Item Activity #
 
 An [extension](https://marketplace.visualstudio.com/items?itemName=ms-devlabs.vsts-extension-workitem-activities) for [Team Services](https://www.visualstudio.com/en-us/products/visual-studio-team-services-vs.aspx) and TFS "15" that tracks your work item activity and provides a page to view your recent work item views and edits. __NOTE: This is not supported on TFS 2015.__


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/liangzhu0810/52d4b51b-cd61-4aea-a7e1-fc96c7343a6a/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.